### PR TITLE
바코드 스캔 로직 리뉴얼 - Top 카메라도 문제없이 스캔되도록 수정

### DIFF
--- a/app/src/main/java/com/bbbtech/barcodescan/BarcodeCropFocusingProcessor.java
+++ b/app/src/main/java/com/bbbtech/barcodescan/BarcodeCropFocusingProcessor.java
@@ -16,8 +16,30 @@ import com.google.android.gms.vision.barcode.Barcode;
  *
  * BarcodeCropFocusingProcessor
  *  중앙 특정 영역 부근만 측정되도록 하는 로직
+ *
+ *  setCameraSourceSize()와 setPreviewRect()를 반드시 호출해 주어야 함
+ *
+ *  BarcodeTracker tracker = new BarcodeTracker(this, this, false);
+ *  final BarcodeCropFocusingProcessor focusingProcessor = new BarcodeCropFocusingProcessor(barcodeDetector, tracker);
+ *  mPreview.setCallback(new CameraSourcePreviewCallback() {
+ *      public void onCameraPreviewSizeDetermined(Size previewSize) {
+ *          focusingProcessor.setCameraSourceSize(previewSize);
+ *      }
+ *  });
+ *  barcodeDetector.setProcessor(focusingProcessor);
+ *
+ *  mPreview.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
+ *      public boolean onPreDraw() {
+ *          mPreview.getViewTreeObserver().removeOnPreDrawListener(this);
+ *
+ *          Rect visibleRect = new Rect();
+ *          mPreview.getLocalVisibleRect(visibleRect);
+ *
+ *          focusingProcessor.setPreviewRect(visibleRect, mPreview.getPaddingLeft(), mPreview.getPaddingTop());
+ *          return true;
+ *      }
+ *  });
  */
-
 public class BarcodeCropFocusingProcessor extends FocusingProcessor<Barcode> {
     private Size cameraSourceSize;  // 카메라 소스 크기
     private Rect previewRect;       // 카메라 프리뷰 영역 전체
@@ -62,25 +84,6 @@ public class BarcodeCropFocusingProcessor extends FocusingProcessor<Barcode> {
                 paddingHorizontal, paddingVertical,
                 paddingHorizontal + cropFrameWidth, paddingVertical + cropFrameHeight);
     }
-
-//    public void setPreviewRect(Rect previewRect, int paddingHorizontal, int paddingVertical) {
-//        int cropFrameWidth = previewRect.right - (paddingHorizontal * 2);
-//        int cropFrameHeight = previewRect.bottom - (paddingVertical * 2);
-//
-//        Rect originalCropFrameRect = new Rect(
-//                paddingHorizontal, paddingVertical,
-//                paddingHorizontal + cropFrameWidth, paddingVertical + cropFrameHeight);
-//
-//        // elemark 2 전용
-//        // 뷰와 소스의 비율 차이만큼 좌표 변환
-//        Rect previewSourceRect = new Rect(0, 0, 1080, 1440);
-//        float widthRatio = (float) previewSourceRect.width() / previewRect.width();
-//        float heightRatio = (float) previewSourceRect.height() / previewRect.height();
-//
-//        this.cropFrameRect = new Rect(
-//                (int) (originalCropFrameRect.left * widthRatio), (int) (originalCropFrameRect.top * heightRatio),
-//                (int) (originalCropFrameRect.right * widthRatio), (int) (originalCropFrameRect.bottom * heightRatio));
-//    }
 
     @Override
     public int selectFocus(Detector.Detections<Barcode> detections) {

--- a/app/src/main/java/com/bbbtech/barcodescan/BarcodeCropFocusingProcessor.java
+++ b/app/src/main/java/com/bbbtech/barcodescan/BarcodeCropFocusingProcessor.java
@@ -1,8 +1,10 @@
 package com.bbbtech.barcodescan;
 
 import android.graphics.Rect;
+import android.graphics.RectF;
 import android.util.SparseArray;
 
+import com.google.android.gms.common.images.Size;
 import com.google.android.gms.vision.Detector;
 import com.google.android.gms.vision.FocusingProcessor;
 import com.google.android.gms.vision.Tracker;
@@ -17,30 +19,68 @@ import com.google.android.gms.vision.barcode.Barcode;
  */
 
 public class BarcodeCropFocusingProcessor extends FocusingProcessor<Barcode> {
-    private Rect cropFrameRect; // 카메라 소스 크기에 맞게 변환된 Crop 영역 Rect
+    private Size cameraSourceSize;  // 카메라 소스 크기
+    private Rect previewRect;       // 카메라 프리뷰 영역 전체
+    private int paddingHorizontal;
+    private int paddingVertical;
+    private Rect cropFrameRect;     // 카메라 프리뷰가 표시되는 뷰에서 padding 부분을 제외한 영역
+
+    private float widthScaleFactor = 1;
+    private float heightScaleFactor = 1;
 
     public BarcodeCropFocusingProcessor(Detector<Barcode> detector, Tracker<Barcode> tracker) {
         super(detector, tracker);
     }
 
+    public void setCameraSourceSize(Size cameraSourceSize) {
+        this.cameraSourceSize = cameraSourceSize;
+
+        if (this.cameraSourceSize != null && previewRect != null) {
+            calculateCropFrameRect();
+        }
+    }
+
     public void setPreviewRect(Rect previewRect, int paddingHorizontal, int paddingVertical) {
+        this.previewRect = previewRect;
+        this.paddingHorizontal = paddingHorizontal;
+        this.paddingVertical = paddingVertical;
+
+        if (cameraSourceSize != null && this.previewRect != null) {
+            calculateCropFrameRect();
+        }
+    }
+
+    private void calculateCropFrameRect() {
         int cropFrameWidth = previewRect.right - (paddingHorizontal * 2);
         int cropFrameHeight = previewRect.bottom - (paddingVertical * 2);
 
-        Rect originalCropFrameRect = new Rect(
-                paddingHorizontal, paddingVertical,
-                paddingHorizontal + cropFrameWidth, paddingVertical + cropFrameHeight);
-
-        // elemark 2 전용
-        // 뷰와 소스의 비율 차이만큼 좌표 변환
-        Rect previewSourceRect = new Rect(0, 0, 1080, 1440);
-        float widthRatio = (float) previewSourceRect.width() / previewRect.width();
-        float heightRatio = (float) previewSourceRect.height() / previewRect.height();
+        // 뷰와 카메라소스의 비율 차이만큼 좌표 변환
+        widthScaleFactor = (float) previewRect.width() / cameraSourceSize.getHeight();
+        heightScaleFactor = (float) previewRect.height() / cameraSourceSize.getWidth();
 
         this.cropFrameRect = new Rect(
-                (int) (originalCropFrameRect.left * widthRatio), (int) (originalCropFrameRect.top * heightRatio),
-                (int) (originalCropFrameRect.right * widthRatio), (int) (originalCropFrameRect.bottom * heightRatio));
+                paddingHorizontal, paddingVertical,
+                paddingHorizontal + cropFrameWidth, paddingVertical + cropFrameHeight);
     }
+
+//    public void setPreviewRect(Rect previewRect, int paddingHorizontal, int paddingVertical) {
+//        int cropFrameWidth = previewRect.right - (paddingHorizontal * 2);
+//        int cropFrameHeight = previewRect.bottom - (paddingVertical * 2);
+//
+//        Rect originalCropFrameRect = new Rect(
+//                paddingHorizontal, paddingVertical,
+//                paddingHorizontal + cropFrameWidth, paddingVertical + cropFrameHeight);
+//
+//        // elemark 2 전용
+//        // 뷰와 소스의 비율 차이만큼 좌표 변환
+//        Rect previewSourceRect = new Rect(0, 0, 1080, 1440);
+//        float widthRatio = (float) previewSourceRect.width() / previewRect.width();
+//        float heightRatio = (float) previewSourceRect.height() / previewRect.height();
+//
+//        this.cropFrameRect = new Rect(
+//                (int) (originalCropFrameRect.left * widthRatio), (int) (originalCropFrameRect.top * heightRatio),
+//                (int) (originalCropFrameRect.right * widthRatio), (int) (originalCropFrameRect.bottom * heightRatio));
+//    }
 
     @Override
     public int selectFocus(Detector.Detections<Barcode> detections) {
@@ -54,9 +94,11 @@ public class BarcodeCropFocusingProcessor extends FocusingProcessor<Barcode> {
 
             // 정상적인 상황에서 바코드가 측정 되었을 때, Crop 영역 외의 바코드는 무시하는 코드
             if (barcode != null && cropFrameRect != null) {
-                Rect barcodeRect = barcode.getBoundingBox();
+                RectF barcodeRectF = getTranslatedRect(barcode.getBoundingBox());
 
                 // 일반적 상황: 여러 개의 바코드 중 cropRect 안에 들어오는 바코드가 존재할 경우
+                Rect barcodeRect = new Rect();
+                barcodeRectF.roundOut(barcodeRect);
                 if (cropFrameRect.contains(barcodeRect)) {
                     detectedId = id;
                 }
@@ -68,5 +110,53 @@ public class BarcodeCropFocusingProcessor extends FocusingProcessor<Barcode> {
             }
         }
         return detectedId;
+    }
+
+    private RectF getTranslatedRect(Rect rect) {
+        RectF rectF = new RectF(rect);
+
+        rectF.left = translateX(rectF.left);
+        rectF.top = translateY(rectF.top);
+        rectF.right = translateX(rectF.right);
+        rectF.bottom = translateY(rectF.bottom);
+
+        return rectF;
+    }
+
+    // 이하 구글 비전 라이브러리에서 가져온 메서드들
+    /**
+     * Adjusts a horizontal value of the supplied value from the preview scale to the view
+     * scale.
+     */
+    private float scaleX(float horizontal) {
+        return horizontal * widthScaleFactor;
+    }
+
+    /**
+     * Adjusts a vertical value of the supplied value from the preview scale to the view scale.
+     */
+    private float scaleY(float vertical) {
+        return vertical * heightScaleFactor;
+    }
+
+    /**
+     * Adjusts the x coordinate from the preview's coordinate system to the view coordinate
+     * system.
+     */
+    private float translateX(float x) {
+        // 중앙에서 스캔을 하는 것이라 우선 불필요하다고 판단
+//        if (mOverlay.mFacing == CameraSource.CAMERA_FACING_FRONT) {
+//            return mOverlay.getWidth() - scaleX(x); // 대칭 -x + 2a (a = 대칭 선이 되는 x절편 좌표 값, a가 중앙값이니 * 2 해서 getWidth())
+//        } else {
+        return scaleX(x);
+//        }
+    }
+
+    /**
+     * Adjusts the y coordinate from the preview's coordinate system to the view coordinate
+     * system.
+     */
+    private float translateY(float y) {
+        return scaleY(y);
     }
 }

--- a/app/src/main/java/com/bbbtech/barcodescan/CameraSourcePreview.java
+++ b/app/src/main/java/com/bbbtech/barcodescan/CameraSourcePreview.java
@@ -39,6 +39,7 @@ public class CameraSourcePreview extends ViewGroup {
     private boolean mCameraAvailable;
     private CameraSource mCameraSource;
     private CameraSourcePreviewListener listener;
+    private CameraSourcePreviewCallback mCallback;
 
     public interface CameraSourcePreviewListener {
         void onCameraNullPointerException();
@@ -103,10 +104,17 @@ public class CameraSourcePreview extends ViewGroup {
         this.listener = listener;
     }
 
+    public void setCallback(CameraSourcePreviewCallback callback) {
+        mCallback = callback;
+    }
+
     @RequiresPermission(Manifest.permission.CAMERA)
     private void startIfReady() throws IOException, SecurityException, CameraNullPointerException {
         if (mStartRequested && mSurfaceAvailable && mCameraAvailable) {
             mCameraSource.start(mSurfaceView.getHolder());
+            if (mCameraSource != null && mCameraSource.getPreviewSize() != null && mCallback != null) {
+                mCallback.onCameraPreviewSizeDetermined(mCameraSource.getPreviewSize());
+            }
             mStartRequested = false;
         }
     }

--- a/app/src/main/java/com/bbbtech/barcodescan/CameraSourcePreviewCallback.java
+++ b/app/src/main/java/com/bbbtech/barcodescan/CameraSourcePreviewCallback.java
@@ -1,0 +1,12 @@
+package com.bbbtech.barcodescan;
+
+import com.google.android.gms.common.images.Size;
+
+/**
+ * Created by Wooseong Kim in barcode-reader on 2017. 5. 29.
+ *
+ * CameraSourcePreviewCallback
+ */
+public interface CameraSourcePreviewCallback {
+    void onCameraPreviewSizeDetermined(Size previewSize);
+}


### PR DESCRIPTION
바코드 스캔 로직 자체에 문제가 있었으나 Top 카메라 스캔을 할 때 더 이슈가 되고 있었음. 

로직 자체를 리뉴얼하여, 스캔시 문제가 없도록 수정.